### PR TITLE
[fixed] v0.25.1 link 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,7 +201,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#5204](https://github.com/thanos-io/thanos/pull/5204) Store: Fix data race in advertised label set in bucket store.
 - [#5242](https://github.com/thanos-io/thanos/pull/5242) Ruler: Make ruler use the correct WAL directory.
 
-## [v0.25.1](https://github.com/thanos-io/thanos/tree/release-0.25) - 2022.03.09
+## [v0.25.1](https://github.com/thanos-io/thanos/releases/tag/v0.25.1) - 2022.03.09
 
 The binaries published with this release are built with Go1.17.8 to avoid [CVE-2022-24921](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24921).
 


### PR DESCRIPTION
Github link to v0.25.1 fixed from v0.25 -> v.0.25.1

Signed-off-by: Vishv Salvi <82429084+Vishvsalvi@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The link for v0.25.1 was redirecting to the github link of v0.25 instead of its own repository

## Verification

I checked the link it redirected to its own repository 
